### PR TITLE
Updating NetCoreWinService to .NET 8, adding publish profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,7 +174,6 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/NET_Core/WindowsService/NetCoreWinService/NetCoreWinService.csproj
+++ b/NET_Core/WindowsService/NetCoreWinService/NetCoreWinService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>dotnet-InstPrj_NetCoreWinService-46921CBA-C574-4093-87CD-82313C94D1FE</UserSecretsId>
   </PropertyGroup>
 

--- a/NET_Core/WindowsService/NetCoreWinService/Properties/PublishProfiles/FrameworkDependent_Winx64.pubxml
+++ b/NET_Core/WindowsService/NetCoreWinService/Properties/PublishProfiles/FrameworkDependent_Winx64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net8.0\publish\Fd_Win64</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
- Updating project from .NET Core 3.1 to .NET 8.0
- Checking in publish profile, which was previously excluded due to gitignore settings